### PR TITLE
[ fix ] significantly reduce roster update cost

### DIFF
--- a/HealersMate.lua
+++ b/HealersMate.lua
@@ -1585,7 +1585,6 @@ function EventHandler()
         
     elseif event == "PLAYER_LOGOUT" or event == "PLAYER_QUITING" then
         
-        
     elseif event == "UNIT_HEALTH" or event == "UNIT_MAXHEALTH" then
         local unit = arg1
         if not IsRelevantUnit(unit) then
@@ -1621,7 +1620,7 @@ function EventHandler()
         end
 
     elseif event == "PARTY_MEMBERS_CHANGED" or event == "RAID_ROSTER_UPDATE" then
-        CheckGroup()
+
     elseif event == "UNIT_PET" or event == "PLAYER_PET_CHANGED" then
         local unit = arg1
         if IsRelevantUnit(unit) then
@@ -1661,7 +1660,8 @@ function EventHandler()
 end
 
 EventHandlerFrame:SetScript("OnEvent", EventHandler)
-
+HealersMateLib:RegisterBucketEvent("PARTY_MEMBERS_CHANGED", 0.3, function () CheckGroup() end)
+HealersMateLib:RegisterBucketEvent("RAID_ROSTER_UPDATE", 0.3, function () CheckGroup() end)
 
 function hmprint(msg)
     if not HMOptions or not HMOptions["Debug"] then


### PR DESCRIPTION
any time multiple people are moved at once the raid update will cause a performance issue, consolidates multiple updates

particularly impactful for addons that update raid formations all at once